### PR TITLE
Align test scene visuals with colliders

### DIFF
--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a0ed35abde5473daa237cf181bbffda
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/DashTrail.prefab
+++ b/Assets/Prefabs/DashTrail.prefab
@@ -1,0 +1,500 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  - component: {fileID: 100003}
+  m_Layer: 0
+  m_Name: DashTrail
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!198 &100002
+ParticleSystem:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  lengthInSec: 5
+  simulationSpeed: 1
+  playOnAwake: 0
+  moveWithTransform: 0
+  scalingMode: 1
+  randomSeed: 1
+  autoRandomSeed: 1
+  useUnscaledTime: 0
+  useRigidbodyForVelocity: 0
+  startDelay:
+    serializedVersion: 2
+    minMaxState: 0
+    scalar: 0
+    minScalar: 0
+    maxScalar: 0
+    minMaxCurve: []
+  startDelayMultiplier: 0
+  startLifetime:
+    serializedVersion: 2
+    minMaxState: 1
+    scalar: 0.2
+    minScalar: 0
+    maxScalar: 0
+    minMaxCurve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+  startLifetimeMultiplier: 0.2
+  startSpeed:
+    serializedVersion: 2
+    minMaxState: 0
+    scalar: 0
+    minScalar: 0
+    maxScalar: 0
+    minMaxCurve: []
+  startSpeedMultiplier: 0
+  startSize3D: 0
+  startSize:
+    serializedVersion: 2
+    minMaxState: 3
+    scalar: 0
+    minScalar: 0.2
+    maxScalar: 0.35
+    minMaxCurve:
+    - serializedVersion: 2
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 2
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+  startSizeMultiplier: 0
+  startSizeX: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  startSizeXMultiplier: 0
+  startSizeY: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  startSizeYMultiplier: 0
+  startSizeZ: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  startSizeZMultiplier: 0
+  startRotation3D: 0
+  startRotation:
+    serializedVersion: 2
+    minMaxState: 0
+    scalar: 0
+    minScalar: 0
+    maxScalar: 0
+    minMaxCurve: []
+  startRotationMultiplier: 0
+  startRotationX: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  startRotationXMultiplier: 0
+  startRotationY: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  startRotationYMultiplier: 0
+  startRotationZ: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  startRotationZMultiplier: 0
+  startColor:
+    serializedVersion: 2
+    minMaxState: 0
+    maxColor: {r: 1, g: 1, b: 1, a: 1}
+    minColor: {r: 1, g: 1, b: 1, a: 1}
+    minMaxGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: 0
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+  gravityModifier:
+    serializedVersion: 2
+    minMaxState: 0
+    scalar: 0
+    minScalar: 0
+    maxScalar: 0
+    minMaxCurve: []
+  gravityModifierMultiplier: 0
+  inheritVelocity:
+    serializedVersion: 2
+    minMaxState: 0
+    scalar: 0
+    minScalar: 0
+    maxScalar: 0
+    minMaxCurve: []
+  inheritVelocityMultiplier: 0
+  maxNumParticles: 1000
+  enableEmission: 1
+  emission:
+    serializedVersion: 2
+    m_Enabled: 1
+    rateOverTime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxScalar: 0
+      minMaxCurve: []
+    rateOverTimeMultiplier: 0
+    rateOverDistance:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxScalar: 0
+      minMaxCurve: []
+    rateOverDistanceMultiplier: 0
+    m_Bursts: []
+  shape:
+    serializedVersion: 2
+    enabled: 1
+    type: 1
+    angle: 25
+    radius: 0.1
+    length: 0
+    donutRadius: 0
+    position: {x: 0, y: 0, z: 0}
+    rotation: {x: 0, y: 0, z: 0}
+    scale: {x: 1, y: 1, z: 1}
+    arc: 360
+    arcMode: 0
+    arcSpread: 0
+    randomDirection: 0
+  colorBySpeed:
+    serializedVersion: 2
+    enabled: 0
+    range: {x: 0, y: 1}
+    gradient:
+      serializedVersion: 2
+      minMaxState: 0
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      minMaxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: 0
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+  colorBySpeedMultiplier: 1
+  sizeOverLifetime:
+    serializedVersion: 2
+    enabled: 0
+    separateAxes: 0
+    size:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 0
+      maxScalar: 0
+      minMaxCurve: []
+    x: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+    y: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+    z: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  sizeOverLifetimeMultiplier: 1
+  sizeBySpeed:
+    serializedVersion: 2
+    enabled: 0
+    separateAxes: 0
+    size:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 0
+      maxScalar: 0
+      minMaxCurve: []
+    x: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+    y: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+    z: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  sizeBySpeedMultiplier: 1
+  rotationOverLifetime:
+    serializedVersion: 2
+    enabled: 0
+    z:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxScalar: 0
+      minMaxCurve: []
+    x: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+    y: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  rotationOverLifetimeMultiplier: 1
+  rotationBySpeed:
+    serializedVersion: 2
+    enabled: 0
+    z:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 0
+      minScalar: 0
+      maxScalar: 0
+      minMaxCurve: []
+    x: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+    y: {serializedVersion: 2, minMaxState: 0, scalar: 0, minScalar: 0, maxScalar: 0, minMaxCurve: []}
+  rotationBySpeedMultiplier: 1
+  colorOverLifetime:
+    serializedVersion: 2
+    enabled: 0
+    color:
+      serializedVersion: 2
+      minMaxState: 0
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      minMaxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: 0
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+  colorOverLifetimeMultiplier: 1
+  lights:
+    serializedVersion: 2
+    enabled: 0
+    ratio: 0
+    useRandomDistribution: 0
+    light: {fileID: 0}
+    useParticleColor: 0
+    sizeAffectsRange: 0
+    alphaAffectsIntensity: 0
+    range: 10
+    intensity: 1
+    maxLights: 20
+  trails:
+    serializedVersion: 2
+    enabled: 0
+    ratio: 1
+    lifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 0
+      maxScalar: 0
+      minMaxCurve: []
+    minVertexDistance: 0.2
+    textureMode: 0
+    worldSpace: 1
+    dieWithParticles: 1
+    sizeAffectsWidth: 0
+    inheritParticleColor: 0
+    colorOverLifetime:
+      serializedVersion: 2
+      minMaxState: 0
+      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      minColor: {r: 1, g: 1, b: 1, a: 1}
+      minMaxGradient:
+        serializedVersion: 2
+        key0: {r: 1, g: 1, b: 1, a: 1}
+        key1: {r: 1, g: 1, b: 1, a: 1}
+        key2: {r: 0, g: 0, b: 0, a: 0}
+        key3: {r: 0, g: 0, b: 0, a: 0}
+        key4: {r: 0, g: 0, b: 0, a: 0}
+        key5: {r: 0, g: 0, b: 0, a: 0}
+        key6: {r: 0, g: 0, b: 0, a: 0}
+        key7: {r: 0, g: 0, b: 0, a: 0}
+        ctime0: 0
+        ctime1: 65535
+        ctime2: 0
+        ctime3: 0
+        ctime4: 0
+        ctime5: 0
+        ctime6: 0
+        ctime7: 0
+        atime0: 0
+        atime1: 65535
+        atime2: 0
+        atime3: 0
+        atime4: 0
+        atime5: 0
+        atime6: 0
+        atime7: 0
+        m_Mode: 0
+        m_ColorSpace: 0
+        m_NumColorKeys: 2
+        m_NumAlphaKeys: 2
+  trailsMultiplier: 1
+  subEmitters:
+    serializedVersion: 2
+    enabled: 0
+    subEmitters: []
+  customData1:
+    serializedVersion: 2
+    enabled: 0
+    vectorComponentCount: 1
+    colorComponentCount: 1
+    mode: 0
+    vectorChannels: []
+    colorGradients: []
+  customData2:
+    serializedVersion: 2
+    enabled: 0
+    vectorComponentCount: 1
+    colorComponentCount: 1
+    mode: 0
+    vectorChannels: []
+    colorGradients: []
+  rendererAlignment: 0
+  flip: {x: 0, y: 0, z: 0}
+  shadowCastingMode: 0
+  receiveShadows: 0
+  enableGPUInstancing: 0
+  allowRoll: 1
+  freeformStretching: 0
+  rotation3D: 0
+  useCustomSimulationSpace: 0
+  customSimulationSpace: {fileID: 0}
+  simulationSpace: 1
+  gravitySource: 0
+--- !u!199 &100003
+ParticleSystemRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_RenderMotionVectors: 1
+  m_MotionVectorGenerationMode: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaxParticleSize: 0.5
+  m_MinParticleSize: 0
+  m_CameraVelocityScale: 0
+  m_VelocityScale: 0
+  m_LengthScale: 1
+  m_SortingFudge: 0
+  m_Pivot: {x: 0, y: 0, z: 0}
+  m_UseCustomVertexStreams: 0
+  m_VertexStreams: 000000000100000002000000030000000600000007000000
+  m_StandardUVs: 0
+  m_RenderMode: 0
+  m_SortingMode: 0
+  m_MinLength: 0
+  m_MaxLength: 5
+  m_ProportionalStretching: 0
+  m_DrawOrder: 0
+  m_Alignment: 0
+  m_Flip: {x: 0, y: 0, z: 0}
+  m_EnableGPUInstancing: 0
+  m_Mesh: {fileID: 0}
+  m_Mesh1: {fileID: 0}
+  m_Mesh2: {fileID: 0}
+  m_Mesh3: {fileID: 0}
+  m_MaskInteraction: 0
+  m_TrailMaterial: {fileID: 0}
+  m_AutoRandomSeed: 1

--- a/Assets/Prefabs/DashTrail.prefab
+++ b/Assets/Prefabs/DashTrail.prefab
@@ -468,7 +468,7 @@ ParticleSystemRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 0000000000000000f000000000000000, type: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0

--- a/Assets/Prefabs/DashTrail.prefab.meta
+++ b/Assets/Prefabs/DashTrail.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2a5fa3b4095443f2801ac0fb3a8b7906
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Prototype.unity
+++ b/Assets/Scenes/Prototype.unity
@@ -285,9 +285,9 @@ SpriteRenderer:
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 2
-  m_Size: {x: 0.8, y: 1.6}
+  m_Size: {x: 0.8, y: 1.8}
   m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
+  m_SpriteTileMode: 1
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
@@ -326,7 +326,7 @@ CapsuleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_Size: {x: 0.8, y: 1.6}
+  m_Size: {x: 0.8, y: 1.8}
   m_Direction: 0
 --- !u!114 &200005
 MonoBehaviour:
@@ -378,7 +378,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 210000}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.85, z: 0}
+  m_LocalPosition: {x: 0, y: -0.95, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -441,7 +441,7 @@ SpriteRenderer:
   m_DrawMode: 2
   m_Size: {x: 12, y: 1}
   m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
+  m_SpriteTileMode: 1
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
@@ -518,7 +518,7 @@ SpriteRenderer:
   m_DrawMode: 2
   m_Size: {x: 3, y: 0.6}
   m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
+  m_SpriteTileMode: 1
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
@@ -595,7 +595,7 @@ SpriteRenderer:
   m_DrawMode: 2
   m_Size: {x: 4, y: 1}
   m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
+  m_SpriteTileMode: 1
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
@@ -672,7 +672,7 @@ SpriteRenderer:
   m_DrawMode: 2
   m_Size: {x: 2, y: 0.6}
   m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
+  m_SpriteTileMode: 1
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0

--- a/Assets/Scenes/Prototype.unity
+++ b/Assets/Scenes/Prototype.unity
@@ -284,8 +284,8 @@ SpriteRenderer:
   m_Color: {r: 0.8313726, g: 0.8313726, b: 0.8313726, a: 1}
   m_FlipX: 0
   m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_DrawMode: 2
+  m_Size: {x: 0.8, y: 1.6}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -408,7 +408,7 @@ Transform:
   m_GameObject: {fileID: 300000}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -1, z: 0}
-  m_LocalScale: {x: 12, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -438,8 +438,8 @@ SpriteRenderer:
   m_Color: {r: 0.2509804, g: 0.4509804, b: 0.3019608, a: 1}
   m_FlipX: 0
   m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_DrawMode: 2
+  m_Size: {x: 12, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -459,7 +459,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 12, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &310000
 GameObject:
@@ -485,7 +485,7 @@ Transform:
   m_GameObject: {fileID: 310000}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 4, y: 1.5, z: 0}
-  m_LocalScale: {x: 3, y: 0.6, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -515,8 +515,8 @@ SpriteRenderer:
   m_Color: {r: 0.40784317, g: 0.2901961, b: 0.47843137, a: 1}
   m_FlipX: 0
   m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_DrawMode: 2
+  m_Size: {x: 3, y: 0.6}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -536,7 +536,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 3, y: 0.6}
   m_EdgeRadius: 0
 --- !u!1 &320000
 GameObject:
@@ -562,7 +562,7 @@ Transform:
   m_GameObject: {fileID: 320000}
   m_LocalRotation: {x: 0, y: 0, z: 0.1305262, w: 0.9914449}
   m_LocalPosition: {x: -2.5, y: 0.5, z: 0}
-  m_LocalScale: {x: 4, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -592,8 +592,8 @@ SpriteRenderer:
   m_Color: {r: 0.30588236, g: 0.3647059, b: 0.46666667, a: 1}
   m_FlipX: 0
   m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_DrawMode: 2
+  m_Size: {x: 4, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -613,7 +613,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 4, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &330000
 GameObject:
@@ -639,7 +639,7 @@ Transform:
   m_GameObject: {fileID: 330000}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -6, y: 3.5, z: 0}
-  m_LocalScale: {x: 2, y: 0.6, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -669,8 +669,8 @@ SpriteRenderer:
   m_Color: {r: 0.65882355, g: 0.3137255, b: 0.2627451, a: 1}
   m_FlipX: 0
   m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_DrawMode: 2
+  m_Size: {x: 2, y: 0.6}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -690,5 +690,5 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 2, y: 0.6}
   m_EdgeRadius: 0

--- a/Assets/Scenes/Prototype.unity
+++ b/Assets/Scenes/Prototype.unity
@@ -240,6 +240,7 @@ GameObject:
   - component: {fileID: 200003}
   - component: {fileID: 200004}
   - component: {fileID: 200005}
+  - component: {fileID: 200006}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -338,8 +339,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3c9d1e7ceea84d3e897fd9fb2f654c6d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   maxRunSpeed: 8
   acceleration: 75
   deceleration: 90
@@ -357,6 +358,36 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 1
   useFallGravityMultiplier: 1
+--- !u!114 &200006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4f33b6e6a8a4bd4b002d278a1a0b2d0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  dashSpeed: 18
+  dashTime: 0.18
+  dashCooldown: 0.25
+  maxAirDashes: 1
+  coyoteTime: 0.1
+  endLagDuration: 0.05
+  groundMask:
+    serializedVersion: 2
+    m_Bits: 1
+  groundCheckSize: {x: 0.78, y: 0.1}
+  groundCheckOffset: {x: 0, y: -0.95}
+  dashTrail: {fileID: 100002, guid: 2a5fa3b4095443f2801ac0fb3a8b7906, type: 3}
+  playerSprite: {fileID: 200002}
+  afterimageSpawnInterval: 0.02
+  afterimageLifetime: 0.15
+  afterimageAlpha: 0.45
+  dashTrailBurstAmount: 16
+  cachedPlayerMovement: {fileID: 200005}
 --- !u!1 &210000
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Afterimage.cs
+++ b/Assets/Scripts/Afterimage.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+
+namespace Platformer
+{
+    [RequireComponent(typeof(SpriteRenderer))]
+    public class Afterimage : MonoBehaviour
+    {
+        private SpriteRenderer spriteRenderer;
+        private Color startColor = Color.white;
+        private float lifetime = 0.15f;
+        private float elapsed;
+
+        private void Awake()
+        {
+            spriteRenderer = GetComponent<SpriteRenderer>();
+        }
+
+        private void Update()
+        {
+            elapsed += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / lifetime);
+            Color color = startColor;
+            color.a = Mathf.Lerp(startColor.a, 0f, t);
+            spriteRenderer.color = color;
+
+            if (elapsed >= lifetime)
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        public void Initialize(Sprite sprite, Color color, Vector3 worldScale, float time, int sortingLayerId, string sortingLayerName, int sortingOrder, bool flipX, bool flipY, Material material)
+        {
+            if (spriteRenderer == null)
+            {
+                spriteRenderer = GetComponent<SpriteRenderer>();
+            }
+
+            spriteRenderer.sprite = sprite;
+            spriteRenderer.flipX = flipX;
+            spriteRenderer.flipY = flipY;
+            spriteRenderer.sortingLayerID = sortingLayerId;
+            spriteRenderer.sortingLayerName = sortingLayerName;
+            spriteRenderer.sortingOrder = sortingOrder;
+            spriteRenderer.drawMode = SpriteDrawMode.Simple;
+            if (material != null)
+            {
+                spriteRenderer.sharedMaterial = material;
+            }
+
+            startColor = color;
+            lifetime = Mathf.Max(0.01f, time);
+            transform.localScale = worldScale;
+            spriteRenderer.color = color;
+        }
+
+        public static void SpawnFromSprite(SpriteRenderer source, float time, float alpha)
+        {
+            if (source == null || source.sprite == null || alpha <= 0f)
+            {
+                return;
+            }
+
+            GameObject clone = new GameObject($"{source.gameObject.name}_Afterimage");
+            clone.transform.position = source.transform.position;
+            clone.transform.rotation = source.transform.rotation;
+            clone.transform.localScale = source.transform.lossyScale;
+            clone.layer = source.gameObject.layer;
+
+            clone.AddComponent<SpriteRenderer>();
+            Afterimage afterimage = clone.AddComponent<Afterimage>();
+
+            Color color = source.color;
+            color.a = alpha;
+
+            afterimage.Initialize(
+                source.sprite,
+                color,
+                source.transform.lossyScale,
+                time,
+                source.sortingLayerID,
+                source.sortingLayerName,
+                source.sortingOrder - 1,
+                source.flipX,
+                source.flipY,
+                source.sharedMaterial);
+        }
+    }
+}

--- a/Assets/Scripts/Afterimage.cs.meta
+++ b/Assets/Scripts/Afterimage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c3a46d9d7a146c8a7f5f03efc70d50f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CameraFollow2D.cs
+++ b/Assets/Scripts/CameraFollow2D.cs
@@ -15,6 +15,7 @@ namespace Platformer
 
         private Vector3 currentVelocity;
         private Vector3 lookAheadOffset;
+        private Vector3 latestTargetPosition;
         private Rigidbody2D targetBody;
         private PlayerMovement playerMovement;
 
@@ -40,7 +41,9 @@ namespace Platformer
 
         private Vector3 CalculateDesiredPosition()
         {
-            Vector3 focusPosition = target.position + worldOffset;
+            Vector3 targetPosition = targetBody != null ? (Vector3)targetBody.position : target.position;
+            latestTargetPosition = targetPosition;
+            Vector3 focusPosition = targetPosition + worldOffset;
             ApplyLookAhead(ref focusPosition);
             ApplyFallBias(ref focusPosition);
 
@@ -101,7 +104,7 @@ namespace Platformer
             }
             else if (playerMovement != null && playerMovement.IsGrounded)
             {
-                focusPosition.y = Mathf.Lerp(focusPosition.y, target.position.y + worldOffset.y, Time.deltaTime * lookAheadSmoothing);
+                focusPosition.y = Mathf.Lerp(focusPosition.y, latestTargetPosition.y + worldOffset.y, Time.deltaTime * lookAheadSmoothing);
             }
         }
 

--- a/Assets/Scripts/DashController2D.cs
+++ b/Assets/Scripts/DashController2D.cs
@@ -1,0 +1,453 @@
+using System;
+using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace Platformer
+{
+    /// <summary>
+    /// DashController2D
+    /// -----------------
+    /// 1. Add this component to the same GameObject as the Rigidbody2D/PlayerMovement.
+    /// 2. Assign the optional ParticleSystem prefab (DashTrail) and SpriteRenderer references in the Inspector.
+    /// 3. Tune dash speed, duration, cooldown, and air-dash counts from the serialized fields below.
+    /// </summary>
+    [RequireComponent(typeof(Rigidbody2D))]
+    public class DashController2D : MonoBehaviour
+    {
+        [Header("Dash Settings")]
+        [SerializeField] private float dashSpeed = 18f;
+        [SerializeField, Min(0f)] private float dashTime = 0.18f;
+        [SerializeField, Min(0f)] private float dashCooldown = 0.25f;
+        [SerializeField, Min(0)] private int maxAirDashes = 1;
+        [SerializeField, Min(0f)] private float coyoteTime = 0.1f;
+        [SerializeField, Min(0f)] private float endLagDuration = 0.05f;
+
+        [Header("Ground Check")]
+        [SerializeField] private LayerMask groundMask = 1;
+        [SerializeField] private Vector2 groundCheckSize = new Vector2(0.8f, 0.1f);
+        [SerializeField] private Vector2 groundCheckOffset = new Vector2(0f, -1f);
+
+        [Header("Visuals")]
+        [SerializeField] private ParticleSystem dashTrail;
+        [SerializeField, Tooltip("Sprite used for afterimages. Defaults to the player's SpriteRenderer.")]
+        private SpriteRenderer playerSprite;
+        [SerializeField, Min(0.005f)] private float afterimageSpawnInterval = 0.02f;
+        [SerializeField, Min(0.01f)] private float afterimageLifetime = 0.15f;
+        [SerializeField, Range(0f, 1f)] private float afterimageAlpha = 0.45f;
+        [SerializeField, Tooltip("How many particles to emit when the dash starts.")]
+        private int dashTrailBurstAmount = 16;
+
+        [Header("Integration")]
+        [SerializeField] private PlayerMovement cachedPlayerMovement;
+
+        public event Action OnDash;
+
+        private Rigidbody2D rb;
+        private PlayerMovement playerMovement;
+
+        private Vector2 dashDirection = Vector2.right;
+        private Vector2 lastAimDirection = Vector2.right;
+
+        private float dashTimer;
+        private float dashCooldownTimer;
+        private float coyoteTimer;
+        private float endLagTimer;
+        private float afterimageTimer;
+        private float originalGravityScale;
+
+        private int dashesRemaining;
+
+        private bool isGrounded;
+        private bool wasGrounded;
+        private bool isDashing;
+        private bool isInEndLag;
+
+        private void Awake()
+        {
+            rb = GetComponent<Rigidbody2D>();
+            playerMovement = cachedPlayerMovement != null ? cachedPlayerMovement : GetComponent<PlayerMovement>();
+            if (playerSprite == null)
+            {
+                playerSprite = GetComponent<SpriteRenderer>();
+            }
+
+            PrepareDashTrailInstance();
+
+            dashesRemaining = Mathf.Max(0, maxAirDashes);
+            lastAimDirection = Vector2.right;
+        }
+
+        private void PrepareDashTrailInstance()
+        {
+            if (dashTrail == null)
+            {
+                return;
+            }
+
+            if (dashTrail.gameObject.scene.rootCount == 0)
+            {
+                string originalName = dashTrail.name;
+                dashTrail = Instantiate(dashTrail, transform.position, Quaternion.identity);
+                dashTrail.name = originalName;
+            }
+
+            dashTrail.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+
+            var main = dashTrail.main;
+            main.stopAction = ParticleSystemStopAction.None;
+            main.simulationSpace = ParticleSystemSimulationSpace.World;
+            main.duration = 0.2f;
+            main.startLifetime = new ParticleSystem.MinMaxCurve(0.15f, 0.25f);
+            main.startSpeed = 0f;
+            main.startSize = new ParticleSystem.MinMaxCurve(0.2f, 0.35f);
+            main.playOnAwake = false;
+
+            var emission = dashTrail.emission;
+            emission.rateOverTime = 0f;
+            emission.rateOverDistance = 0f;
+
+            var trails = dashTrail.trails;
+            trails.enabled = true;
+            trails.lifetime = 0.2f;
+            trails.dieWithParticles = true;
+            trails.ratio = 1f;
+            trails.worldSpace = true;
+            trails.inheritParticleColor = true;
+
+            var colorOverLifetime = dashTrail.colorOverLifetime;
+            colorOverLifetime.enabled = true;
+            Gradient gradient = new Gradient();
+            gradient.SetKeys(
+                new[] { new GradientColorKey(Color.white, 0f), new GradientColorKey(Color.white, 0.3f) },
+                new[] { new GradientAlphaKey(1f, 0f), new GradientAlphaKey(0f, 1f) });
+            colorOverLifetime.color = new ParticleSystem.MinMaxGradient(gradient);
+        }
+
+        private void Update()
+        {
+            float deltaTime = Time.deltaTime;
+
+            UpdateGroundedState(deltaTime);
+            UpdateCooldowns(deltaTime);
+
+            Vector2 input = GetDirectionalInput();
+            if (input.sqrMagnitude > 0.01f)
+            {
+                lastAimDirection = SnapToEightDirections(input.normalized);
+            }
+            else if (rb.linearVelocity.sqrMagnitude > 0.01f)
+            {
+                lastAimDirection = SnapToEightDirections(rb.linearVelocity.normalized);
+            }
+
+            if (!isDashing && !isInEndLag && GetDashPressed())
+            {
+                TryStartDash(input);
+            }
+
+            if (isDashing)
+            {
+                UpdateDash(deltaTime);
+            }
+            else if (isInEndLag)
+            {
+                UpdateEndLag(deltaTime);
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            if (!isDashing)
+            {
+                return;
+            }
+
+            rb.linearVelocity = dashDirection * dashSpeed;
+            if (dashTrail != null)
+            {
+                dashTrail.transform.position = transform.position;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (isDashing)
+            {
+                EndDash();
+            }
+
+            if (dashTrail != null)
+            {
+                dashTrail.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            }
+
+            if (playerMovement != null)
+            {
+                playerMovement.SetMovementSuppressed(false);
+            }
+
+            isInEndLag = false;
+        }
+
+        private void UpdateGroundedState(float deltaTime)
+        {
+            wasGrounded = isGrounded;
+            Vector2 origin = (Vector2)transform.position + groundCheckOffset;
+            RaycastHit2D hit = Physics2D.BoxCast(origin, groundCheckSize, 0f, Vector2.down, 0f, groundMask);
+            isGrounded = hit.collider != null;
+
+            if (isGrounded)
+            {
+                coyoteTimer = coyoteTime;
+                if (!wasGrounded)
+                {
+                    dashesRemaining = Mathf.Max(0, maxAirDashes);
+                }
+            }
+            else
+            {
+                coyoteTimer = Mathf.Max(0f, coyoteTimer - deltaTime);
+            }
+        }
+
+        private void UpdateCooldowns(float deltaTime)
+        {
+            if (dashCooldownTimer > 0f)
+            {
+                dashCooldownTimer = Mathf.Max(0f, dashCooldownTimer - deltaTime);
+            }
+        }
+
+        private void TryStartDash(Vector2 input)
+        {
+            if (!CanDash())
+            {
+                return;
+            }
+
+            Vector2 desiredDirection = DetermineDashDirection(input);
+            BeginDash(desiredDirection);
+        }
+
+        private bool CanDash()
+        {
+            if (dashCooldownTimer > 0f)
+            {
+                return false;
+            }
+
+            if (isGrounded || coyoteTimer > 0f)
+            {
+                return true;
+            }
+
+            return dashesRemaining > 0;
+        }
+
+        private Vector2 DetermineDashDirection(Vector2 input)
+        {
+            Vector2 snappedInput = SnapToEightDirections(input);
+
+            if (snappedInput.sqrMagnitude < 0.01f)
+            {
+                snappedInput = lastAimDirection.sqrMagnitude > 0.01f
+                    ? lastAimDirection
+                    : Vector2.right;
+            }
+
+            lastAimDirection = snappedInput;
+            return snappedInput;
+        }
+
+        private static Vector2 SnapToEightDirections(Vector2 direction)
+        {
+            if (direction.sqrMagnitude < 0.0001f)
+            {
+                return Vector2.zero;
+            }
+
+            direction.Normalize();
+            float angle = Mathf.Atan2(direction.y, direction.x);
+            float step = Mathf.PI / 4f;
+            int index = Mathf.RoundToInt(angle / step);
+            float snappedAngle = index * step;
+            return new Vector2(Mathf.Cos(snappedAngle), Mathf.Sin(snappedAngle)).normalized;
+        }
+
+        private void BeginDash(Vector2 direction)
+        {
+            dashDirection = direction;
+            isDashing = true;
+            isInEndLag = false;
+            dashTimer = dashTime;
+            dashCooldownTimer = dashCooldown;
+            afterimageTimer = 0f;
+
+            originalGravityScale = rb.gravityScale;
+            rb.gravityScale = 0f;
+            rb.linearVelocity = direction * dashSpeed;
+
+            if (!isGrounded && coyoteTimer <= 0f && dashesRemaining > 0)
+            {
+                dashesRemaining--;
+            }
+
+            if (playerMovement != null)
+            {
+                playerMovement.SetMovementSuppressed(true);
+            }
+
+            PlayDashTrail();
+            OnDash?.Invoke();
+            // If using Cinemachine ImpulseSource, you can trigger it here for a camera shake.
+        }
+
+        private void UpdateDash(float deltaTime)
+        {
+            dashTimer -= deltaTime;
+            if (dashTimer <= 0f)
+            {
+                EndDash();
+                return;
+            }
+
+            afterimageTimer -= deltaTime;
+            if (afterimageTimer <= 0f)
+            {
+                SpawnAfterimage();
+                afterimageTimer = afterimageSpawnInterval;
+            }
+        }
+
+        private void EndDash()
+        {
+            if (!isDashing)
+            {
+                return;
+            }
+
+            isDashing = false;
+            rb.gravityScale = originalGravityScale;
+
+            if (dashTrail != null)
+            {
+                dashTrail.Stop(true, ParticleSystemStopBehavior.StopEmitting);
+            }
+
+            if (endLagDuration > 0f)
+            {
+                isInEndLag = true;
+                endLagTimer = endLagDuration;
+            }
+            else if (playerMovement != null)
+            {
+                playerMovement.SetMovementSuppressed(false);
+            }
+        }
+
+        private void UpdateEndLag(float deltaTime)
+        {
+            endLagTimer -= deltaTime;
+            if (endLagTimer > 0f)
+            {
+                return;
+            }
+
+            isInEndLag = false;
+            if (playerMovement != null)
+            {
+                playerMovement.SetMovementSuppressed(false);
+            }
+        }
+
+        private void PlayDashTrail()
+        {
+            if (dashTrail == null)
+            {
+                return;
+            }
+
+            dashTrail.transform.position = transform.position;
+            dashTrail.Clear(true);
+            dashTrail.Play(true);
+
+            if (dashTrailBurstAmount > 0)
+            {
+                dashTrail.Emit(dashTrailBurstAmount);
+            }
+        }
+
+        private void SpawnAfterimage()
+        {
+            if (playerSprite == null)
+            {
+                return;
+            }
+
+            Afterimage.SpawnFromSprite(playerSprite, afterimageLifetime, afterimageAlpha);
+        }
+
+        private Vector2 GetDirectionalInput()
+        {
+            Vector2 input = Vector2.zero;
+#if ENABLE_INPUT_SYSTEM
+            if (Gamepad.current != null)
+            {
+                input += Gamepad.current.leftStick.ReadValue();
+            }
+
+            if (Keyboard.current != null)
+            {
+                if (Keyboard.current.aKey.isPressed || Keyboard.current.leftArrowKey.isPressed)
+                {
+                    input.x -= 1f;
+                }
+
+                if (Keyboard.current.dKey.isPressed || Keyboard.current.rightArrowKey.isPressed)
+                {
+                    input.x += 1f;
+                }
+
+                if (Keyboard.current.wKey.isPressed || Keyboard.current.upArrowKey.isPressed)
+                {
+                    input.y += 1f;
+                }
+
+                if (Keyboard.current.sKey.isPressed || Keyboard.current.downArrowKey.isPressed)
+                {
+                    input.y -= 1f;
+                }
+            }
+#endif
+            input += new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
+            input = Vector2.ClampMagnitude(input, 1f);
+            return input;
+        }
+
+        private bool GetDashPressed()
+        {
+            bool pressed = Input.GetKeyDown(KeyCode.LeftShift) || Input.GetKeyDown(KeyCode.RightShift) || Input.GetKeyDown(KeyCode.JoystickButton0);
+#if ENABLE_INPUT_SYSTEM
+            if (!pressed && Keyboard.current != null)
+            {
+                pressed |= Keyboard.current.leftShiftKey.wasPressedThisFrame || Keyboard.current.rightShiftKey.wasPressedThisFrame;
+            }
+
+            if (!pressed && Gamepad.current != null)
+            {
+                pressed |= Gamepad.current.buttonSouth.wasPressedThisFrame;
+            }
+#endif
+            return pressed;
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            Gizmos.color = Color.cyan;
+            Vector3 origin = transform.position + (Vector3)groundCheckOffset;
+            Gizmos.DrawWireCube(origin, groundCheckSize);
+        }
+    }
+}

--- a/Assets/Scripts/DashController2D.cs.meta
+++ b/Assets/Scripts/DashController2D.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4f33b6e6a8a4bd4b002d278a1a0b2d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -133,8 +133,8 @@ namespace Platformer
 
         private void HandleJumpInput()
         {
-            bool jumpPressed = Input.GetButtonDown("Jump") || Input.GetKeyDown(KeyCode.S);
-            bool jumpReleased = Input.GetButtonUp("Jump") || Input.GetKeyUp(KeyCode.S);
+            bool jumpPressed = Input.GetButtonDown("Jump") || Input.GetKeyDown(KeyCode.W);
+            bool jumpReleased = Input.GetButtonUp("Jump") || Input.GetKeyUp(KeyCode.W);
 
             if (jumpPressed)
             {

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace Platformer
 {
-    [RequireComponent(typeof(Rigidbody2D))]
+    [RequireComponent(typeof(Rigidbody2D), typeof(CapsuleCollider2D))]
     public class PlayerMovement : MonoBehaviour
     {
         [Header("Movement")]
@@ -15,10 +15,26 @@ namespace Platformer
         [Header("Jumping")]
         [SerializeField] private float jumpHeight = 4.5f;
         [SerializeField] private float jumpTimeToApex = 0.35f;
-        [SerializeField] private float coyoteTime = 0.12f;
+        [SerializeField] private float coyoteTime = 0.055f;
         [SerializeField] private float jumpBufferTime = 0.12f;
         [SerializeField] private float fallGravityMultiplier = 1.8f;
         [SerializeField] private float shortHopGravityMultiplier = 2.2f;
+
+        [Header("Air Options")]
+        [SerializeField] private bool enableDoubleJump = true;
+        [Min(0)]
+        [SerializeField] private int maxAirJumps = 1;
+
+        [Header("Crouch Charge Jump")]
+        [SerializeField] private bool enableCrouchCharge = true;
+        [SerializeField] private float chargeTime = 0.35f;
+        [SerializeField] private float minJumpMultiplier = 1f;
+        [SerializeField] private float maxJumpMultiplier = 1.6f;
+
+        [Header("Wall Interaction")]
+        [SerializeField] private bool enableWallSlide = false;
+        [SerializeField] private float wallSlideSpeed = 3f;
+        [SerializeField] private float wallCheckDistance = 0.08f;
 
         [Header("Ground Check")]
         [SerializeField] private Transform groundCheck;
@@ -29,7 +45,10 @@ namespace Platformer
         [Tooltip("If true gravity will be scaled by fallGravityMultiplier while falling.")]
         [SerializeField] private bool useFallGravityMultiplier = true;
 
+        private const float GroundCheckDistance = 0.05f;
+
         private Rigidbody2D body;
+        private CapsuleCollider2D capsule;
         private Vector2 currentVelocity;
 
         private float baseGravityScale;
@@ -40,18 +59,27 @@ namespace Platformer
         private float coyoteCounter;
         private float jumpBufferCounter;
         private bool isJumpCut;
-        private bool wasGroundedLastFrame;
         private bool movementSuppressed;
+        private bool isCrouching;
+        private bool isWallSliding;
+        private bool isTouchingWall;
+        private int wallDirection;
+        private float crouchChargeTimer;
+        private int airJumpsRemaining;
 
         public bool IsGrounded { get; private set; }
         public Vector2 Velocity => body.linearVelocity;
         public bool MovementSuppressed => movementSuppressed;
+        public bool IsCrouching => isCrouching;
 
         private void Awake()
         {
             body = GetComponent<Rigidbody2D>();
+            capsule = GetComponent<CapsuleCollider2D>();
+            body.interpolation = RigidbodyInterpolation2D.Interpolate;
             baseGravityScale = body.gravityScale;
             CalculateGravity();
+            ResetAirJumpCount();
         }
 
         private void CalculateGravity()
@@ -67,6 +95,7 @@ namespace Platformer
             inputX = movementSuppressed ? 0f : Input.GetAxisRaw("Horizontal");
             currentVelocity = body.linearVelocity;
 
+            UpdateCrouchState();
             UpdateTimers();
             if (!movementSuppressed)
             {
@@ -76,12 +105,15 @@ namespace Platformer
 
         private void FixedUpdate()
         {
+            RefreshContactStates();
+
             if (movementSuppressed)
             {
                 return;
             }
 
             ApplyHorizontalMovement();
+            HandleWallSlide();
             ApplyGravityModifiers();
         }
 
@@ -93,25 +125,28 @@ namespace Platformer
             }
             else
             {
-                coyoteCounter -= Time.deltaTime;
+                coyoteCounter = Mathf.Max(coyoteCounter - Time.deltaTime, 0f);
             }
 
-            jumpBufferCounter -= Time.deltaTime;
+            jumpBufferCounter = Mathf.Max(jumpBufferCounter - Time.deltaTime, 0f);
         }
 
         private void HandleJumpInput()
         {
-            if (Input.GetButtonDown("Jump"))
+            bool jumpPressed = Input.GetButtonDown("Jump") || Input.GetKeyDown(KeyCode.S);
+            bool jumpReleased = Input.GetButtonUp("Jump") || Input.GetKeyUp(KeyCode.S);
+
+            if (jumpPressed)
             {
                 jumpBufferCounter = jumpBufferTime;
             }
 
-            if (CanJump())
+            if (TryConsumeJump(out bool groundedJump, out float jumpMultiplier))
             {
-                PerformJump();
+                PerformJump(groundedJump, jumpMultiplier);
             }
 
-            if (Input.GetButtonUp("Jump"))
+            if (jumpReleased)
             {
                 if (currentVelocity.y > 0f)
                 {
@@ -128,6 +163,10 @@ namespace Platformer
             }
 
             float targetSpeed = inputX * maxRunSpeed;
+            if (isCrouching)
+            {
+                targetSpeed = 0f;
+            }
             float speedDifference = targetSpeed - body.linearVelocity.x;
 
             float accelRate = Mathf.Abs(targetSpeed) > 0.01f
@@ -145,18 +184,59 @@ namespace Platformer
             body.linearVelocity = new Vector2(newVelocityX, body.linearVelocity.y);
         }
 
-        private bool CanJump()
+        /// <summary>
+        /// Consumes a buffered jump if we are within the coyote window or have air jumps remaining.
+        /// Returns true when a jump should be performed and outputs whether it counts as a grounded jump
+        /// plus the multiplier that should be applied to the jump velocity.
+        /// </summary>
+        private bool TryConsumeJump(out bool groundedJump, out float jumpMultiplier)
         {
-            return jumpBufferCounter > 0f && coyoteCounter > 0f;
+            groundedJump = false;
+            jumpMultiplier = 1f;
+
+            if (jumpBufferCounter <= 0f)
+            {
+                return false;
+            }
+
+            if (coyoteCounter > 0f)
+            {
+                groundedJump = true;
+                jumpMultiplier = isCrouching ? GetChargedJumpMultiplier() : 1f;
+                return true;
+            }
+
+            if (enableDoubleJump && airJumpsRemaining > 0)
+            {
+                airJumpsRemaining--;
+                return true;
+            }
+
+            return false;
         }
 
-        private void PerformJump()
+        /// <summary>
+        /// Applies the jump velocity and resets any state tied to the start of a jump.
+        /// </summary>
+        private void PerformJump(bool groundedJump, float jumpMultiplier)
         {
             jumpBufferCounter = 0f;
             coyoteCounter = 0f;
             isJumpCut = false;
 
-            body.linearVelocity = new Vector2(body.linearVelocity.x, jumpVelocity);
+            float appliedJumpVelocity = jumpVelocity * jumpMultiplier;
+            body.linearVelocity = new Vector2(body.linearVelocity.x, appliedJumpVelocity);
+
+            if (groundedJump)
+            {
+                ResetAirJumpCount();
+                if (enableCrouchCharge)
+                {
+                    crouchChargeTimer = 0f;
+                }
+            }
+
+            isCrouching = false;
         }
 
         private void ApplyGravityModifiers()
@@ -167,6 +247,12 @@ namespace Platformer
             }
 
             if (!useFallGravityMultiplier)
+            {
+                body.gravityScale = baseGravityScale;
+                return;
+            }
+
+            if (isWallSliding)
             {
                 body.gravityScale = baseGravityScale;
                 return;
@@ -183,23 +269,6 @@ namespace Platformer
             else
             {
                 body.gravityScale = baseGravityScale;
-            }
-        }
-
-        private void LateUpdate()
-        {
-            CheckGroundedState();
-        }
-
-        private void CheckGroundedState()
-        {
-            Collider2D collider = Physics2D.OverlapBox(groundCheck.position, groundCheckSize, 0f, groundLayers);
-            wasGroundedLastFrame = IsGrounded;
-            IsGrounded = collider != null;
-
-            if (IsGrounded && !wasGroundedLastFrame)
-            {
-                isJumpCut = false;
             }
         }
 
@@ -221,11 +290,177 @@ namespace Platformer
             if (suppressed)
             {
                 inputX = 0f;
+                isCrouching = false;
+                crouchChargeTimer = 0f;
             }
             else
             {
                 body.gravityScale = baseGravityScale;
             }
+        }
+
+        /// <summary>
+        /// Polls the environment for ground and wall contact information so the movement state stays in sync with physics.
+        /// </summary>
+        private void RefreshContactStates()
+        {
+            UpdateGroundState();
+            UpdateWallState();
+        }
+
+        /// <summary>
+        /// Uses a downward box cast below the ground check to confirm grounded state and refresh the air jump counter.
+        /// </summary>
+        private void UpdateGroundState()
+        {
+            if (groundCheck == null)
+            {
+                return;
+            }
+
+            RaycastHit2D hit = Physics2D.BoxCast(groundCheck.position, groundCheckSize, 0f, Vector2.down, GroundCheckDistance, groundLayers);
+            IsGrounded = hit.collider != null && Vector2.Angle(hit.normal, Vector2.up) <= 60f;
+
+            if (IsGrounded)
+            {
+                isJumpCut = false;
+                ResetAirJumpCount();
+            }
+        }
+
+        /// <summary>
+        /// Checks for walls directly beside the capsule so we can decide if wall sliding should activate.
+        /// </summary>
+        private void UpdateWallState()
+        {
+            isTouchingWall = false;
+            wallDirection = 0;
+
+            if (capsule == null || IsGrounded)
+            {
+                return;
+            }
+
+            Bounds bounds = capsule.bounds;
+            Vector2 origin = bounds.center;
+            Vector2 size = new Vector2(bounds.size.x * 0.9f, bounds.size.y * 0.9f);
+
+            RaycastHit2D leftHit = Physics2D.BoxCast(origin, size, 0f, Vector2.left, wallCheckDistance, groundLayers);
+            if (leftHit.collider != null && leftHit.normal.x > 0.1f)
+            {
+                isTouchingWall = true;
+                wallDirection = -1;
+                return;
+            }
+
+            RaycastHit2D rightHit = Physics2D.BoxCast(origin, size, 0f, Vector2.right, wallCheckDistance, groundLayers);
+            if (rightHit.collider != null && rightHit.normal.x < -0.1f)
+            {
+                isTouchingWall = true;
+                wallDirection = 1;
+            }
+        }
+
+        /// <summary>
+        /// Applies a gentle downward clamp when wall sliding is enabled and the player pushes into a wall while falling.
+        /// </summary>
+        private void HandleWallSlide()
+        {
+            isWallSliding = false;
+
+            if (!enableWallSlide || IsGrounded || !isTouchingWall)
+            {
+                return;
+            }
+
+            if (Mathf.Abs(inputX) < 0.01f || Mathf.RoundToInt(Mathf.Sign(inputX)) != wallDirection)
+            {
+                return;
+            }
+
+            if (body.linearVelocity.y < 0f)
+            {
+                isWallSliding = true;
+                float clampedY = Mathf.Max(body.linearVelocity.y, -Mathf.Abs(wallSlideSpeed));
+                body.linearVelocity = new Vector2(body.linearVelocity.x, clampedY);
+            }
+        }
+
+        /// <summary>
+        /// Tracks whether the crouch input is held and builds jump charge while grounded.
+        /// </summary>
+        private void UpdateCrouchState()
+        {
+            bool crouchInputHeld = !movementSuppressed && (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl) || Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow));
+            bool canCrouch = IsGrounded && crouchInputHeld;
+
+            isCrouching = canCrouch;
+
+            if (!enableCrouchCharge)
+            {
+                crouchChargeTimer = 0f;
+                return;
+            }
+
+            if (isCrouching)
+            {
+                crouchChargeTimer = Mathf.Min(crouchChargeTimer + Time.deltaTime, chargeTime);
+            }
+            else
+            {
+                crouchChargeTimer = Mathf.MoveTowards(crouchChargeTimer, 0f, Time.deltaTime * 2f);
+            }
+        }
+
+        /// <summary>
+        /// Converts the current crouch charge timer into a multiplier that scales the base jump velocity.
+        /// </summary>
+        private float GetChargedJumpMultiplier()
+        {
+            if (!enableCrouchCharge)
+            {
+                return 1f;
+            }
+
+            if (chargeTime <= Mathf.Epsilon)
+            {
+                return maxJumpMultiplier;
+            }
+
+            float t = Mathf.Clamp01(crouchChargeTimer / chargeTime);
+            return Mathf.Lerp(minJumpMultiplier, maxJumpMultiplier, t);
+        }
+
+        /// <summary>
+        /// Resets the pool of air jumps to match the inspector configuration.
+        /// </summary>
+        private void ResetAirJumpCount()
+        {
+            airJumpsRemaining = enableDoubleJump ? maxAirJumps : 0;
+        }
+
+        private void OnValidate()
+        {
+            jumpTimeToApex = Mathf.Max(0.01f, jumpTimeToApex);
+            maxAirJumps = Mathf.Max(0, maxAirJumps);
+            chargeTime = Mathf.Max(0.01f, chargeTime);
+            minJumpMultiplier = Mathf.Max(0f, minJumpMultiplier);
+            maxJumpMultiplier = Mathf.Max(minJumpMultiplier, maxJumpMultiplier);
+            wallSlideSpeed = Mathf.Max(0.1f, wallSlideSpeed);
+            wallCheckDistance = Mathf.Max(0.01f, wallCheckDistance);
+
+            if (!Application.isPlaying)
+            {
+                body = GetComponent<Rigidbody2D>();
+                capsule = GetComponent<CapsuleCollider2D>();
+            }
+
+            if (body != null)
+            {
+                CalculateGravity();
+            }
+
+            ResetAirJumpCount();
         }
     }
 }

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -41,9 +41,11 @@ namespace Platformer
         private float jumpBufferCounter;
         private bool isJumpCut;
         private bool wasGroundedLastFrame;
+        private bool movementSuppressed;
 
         public bool IsGrounded { get; private set; }
         public Vector2 Velocity => body.linearVelocity;
+        public bool MovementSuppressed => movementSuppressed;
 
         private void Awake()
         {
@@ -62,15 +64,23 @@ namespace Platformer
 
         private void Update()
         {
-            inputX = Input.GetAxisRaw("Horizontal");
+            inputX = movementSuppressed ? 0f : Input.GetAxisRaw("Horizontal");
             currentVelocity = body.linearVelocity;
 
             UpdateTimers();
-            HandleJumpInput();
+            if (!movementSuppressed)
+            {
+                HandleJumpInput();
+            }
         }
 
         private void FixedUpdate()
         {
+            if (movementSuppressed)
+            {
+                return;
+            }
+
             ApplyHorizontalMovement();
             ApplyGravityModifiers();
         }
@@ -112,6 +122,11 @@ namespace Platformer
 
         private void ApplyHorizontalMovement()
         {
+            if (movementSuppressed)
+            {
+                return;
+            }
+
             float targetSpeed = inputX * maxRunSpeed;
             float speedDifference = targetSpeed - body.linearVelocity.x;
 
@@ -146,6 +161,11 @@ namespace Platformer
 
         private void ApplyGravityModifiers()
         {
+            if (movementSuppressed)
+            {
+                return;
+            }
+
             if (!useFallGravityMultiplier)
             {
                 body.gravityScale = baseGravityScale;
@@ -192,6 +212,20 @@ namespace Platformer
 
             Gizmos.color = Color.green;
             Gizmos.DrawWireCube(groundCheck.position, groundCheckSize);
+        }
+
+        public void SetMovementSuppressed(bool suppressed)
+        {
+            movementSuppressed = suppressed;
+
+            if (suppressed)
+            {
+                inputX = 0f;
+            }
+            else
+            {
+                body.gravityScale = baseGravityScale;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- scale the player sprite to match the capsule collider for clearer size feedback
- expand ground, platform, and slope sprites to fill their BoxCollider2D bounds while preserving color coding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daaac11550832b82d5d39403b35bb2